### PR TITLE
Differents item names on update 3.4

### DIFF
--- a/src/models/resources/items.js
+++ b/src/models/resources/items.js
@@ -862,5 +862,16 @@ export default [
   {
     "serverName": "*Item_CapacitorPlate*",
     "name": "Capacitor Plate"
-  }
+  },
+  {
+    "serverName": "Item_RooksDecree",
+    "name": "Rooks Decree"
+  }, {
+    "serverName": "Item_Pulseweave",
+    "name": "Pulseweave"
+  },
+  {
+    "serverName": "Item_CapacitorPlate",
+    "name": "Capacitor Plate"
+  },
 ]

--- a/src/models/resources/items.js
+++ b/src/models/resources/items.js
@@ -873,5 +873,5 @@ export default [
   {
     "serverName": "Item_CapacitorPlate",
     "name": "Capacitor Plate"
-  },
+  }
 ]


### PR DESCRIPTION
"items" array contains different names from "itemsGrants"

This is another reason why we should replace items names automatic. We can't test until vainglory update is deployed